### PR TITLE
Fix liquid 'and' syntax

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <!-- Article -->
-<article{% if site.addthisId == "" && site.disqusUsername == "" %} class="noBorder"{% endif %}>
+<article{% if site.addthisId == "" and site.disqusUsername == "" %} class="noBorder"{% endif %}>
 
 	<!-- Article title -->
 	<h1>{{ page.title }}</h1>


### PR DESCRIPTION
`&&` is invalid liquid. we need to use `and` keyword instead.

I was getting a:

```
   Liquid Warning: Liquid syntax error (line 2): Unexpected character & in "site.addthisId == "" && site.disqusUsername == """ in /_layouts/article.html
```
